### PR TITLE
added backgroundOpacityReduce

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -246,3 +246,12 @@ function validFontList(fontsListed) {
 
   return true;
 }
+
+/**
+ * Returns a background image of a inputed hex at a requested opactiy 
+ * @param {string} colour - Hex code from platform. 
+ * @param {number} opacity - How much traspancy do you want between 1 and 0? 
+ */
+function backgroundOpacityReduce (colour, opacity) {
+  return `url("data:image/svg+xml,%3Csvg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='50px' height='50px' viewBox='0 0 50 50' enable-background='new 0 0 50 50' xml:space='preserve'%3E%3Crect opacity='${opacity}' fill='${colour.replace('#','%23')}' width='50' height='50'/%3E%3C/svg%3E")`;
+}


### PR DESCRIPTION
This function allows us to get set a background colour a different opacity without adding an opacity to the text

This following example will return a 60% gray of the inputed black colour. 
`
getBackgroundImage({{{account.colors.black}}}, 0.6)
`

The object returned is a image that should be set as a background-image property.

This following example gets the light-primary css variable to be 30% of the regular primary colour. 

`  let primary = window.getComputedStyle(document.body).getPropertyValue('--primary');
      document.body.style.setProperty('--light-primary', getBackgroundImage(primary, 0.3));`  