### PR TITLE
remove-master-only-tag-deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,6 @@ on:
  push:
     tags:
       - '*'
-    branches:
-      - master
-
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
for some reason, this breaks tagged deploy. This means we will still be able to create versions on the s3 even if it's not master. PLease don't create tags manually