### PR TITLE
updated workflows to correctly install npm packages

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Install Dependencies
-        run: npm install --only=prod
+        run: npm i ci
 
       - name: Build for production
         run: npm run build-ci

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
         
       - name: Install Dependencies
-        run: npm install
+        run: npm i ci
 
       - name: Build for production
         run: npm run build


### PR DESCRIPTION
### Problem
The 'Bump version and release' workflow incorrectly only installed the production dependencies

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Root Cause
Webpack dependencies are devDependencies, they are used for build-time, not runtime. So we require those dependencies in CI as we need to build the bundle. `npm install --only=prod` doesn't include devDependencies.

### Solution
Ensured we install all dependencies, and install from the lock file: `npm i ci`

### Quality Control & Communication
- [x] I have tested this code; either by automated tests or manually.
- [ ] If required, I have made corresponding changes to the documentation.

### Potential Risks
This fixes the  'Bump version and release' workflow so its pretty critical to add in.