### PR TITLE
add optional chaining to conditions for setupMto

### DIFF
--- a/modules/mto.js
+++ b/modules/mto.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 // This is getting removed so no point linting
-
+//
 // get sidebar element on the current page
 const getSidebar = () => {
   const sidebar = window.top.document.querySelectorAll(


### PR DESCRIPTION
### Problem
Script is causing templates to error out when on top level of inputs panel either in variations screen or documents screen

### Type of Change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)

### Root Cause
code was attempting to read an undefined element

### Solution
Add optional chaining - won't run on export so should be fine

### Quality Control & Communication
- [X] I have tested this code; either by automated tests or manually.